### PR TITLE
feat: 인기 검색어 조회 API 구현, 검색어 저장을 위한 in-memory DB 작업 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.3.8'
 
 }
 

--- a/src/main/java/com/hgbong/blogsearch/config/ModelMapperConfig.java
+++ b/src/main/java/com/hgbong/blogsearch/config/ModelMapperConfig.java
@@ -1,0 +1,17 @@
+package com.hgbong.blogsearch.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class ModelMapperConfig {
+
+    @Bean
+    public ModelMapper modelMapper() {
+        ModelMapper modelMapper = new ModelMapper();
+        // todo  모델 변경 별 필요한 공통 설정
+        return modelMapper;
+    }
+}

--- a/src/main/java/com/hgbong/blogsearch/controller/BlogController.java
+++ b/src/main/java/com/hgbong/blogsearch/controller/BlogController.java
@@ -4,6 +4,7 @@ import com.hgbong.blogsearch.model.common.PageResponse;
 import com.hgbong.blogsearch.model.search.BlogSearchCriteria;
 import com.hgbong.blogsearch.model.search.DocumentDto;
 import com.hgbong.blogsearch.service.BlogSearchService;
+import com.hgbong.blogsearch.service.QueryService;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,14 +14,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/blogs")
 @RequiredArgsConstructor
-public class BlogSearchController {
+public class BlogController {
 
     private final BlogSearchService blogSearchService;
+
+    private final QueryService queryService;
 
     @ApiOperation(value = "블로그 검색", notes = "키워드를 입력하여 블로그를 페이지 구조로 조회할 수 있다.\n" +
         "sort 기능을 사용해 정확도(accuracy)순 또는 최신순(recency)으로 정렬하여 조회 가능하다. (기본정렬: accuracy)")
     @GetMapping
     public PageResponse<DocumentDto> pageBlogs(BlogSearchCriteria blogSearch) {
+
+        // todo 검색 기능과 분리 - insert 실패해도 API 동작 , 조회 성능문제 되지 않도록 처리 등
+        queryService.addQueryCount(blogSearch.getQuery());
+
         return blogSearchService.pageBlogs(blogSearch);
     }
 }

--- a/src/main/java/com/hgbong/blogsearch/controller/QueryController.java
+++ b/src/main/java/com/hgbong/blogsearch/controller/QueryController.java
@@ -1,0 +1,25 @@
+package com.hgbong.blogsearch.controller;
+
+import com.hgbong.blogsearch.model.query.QueryDto;
+import com.hgbong.blogsearch.service.QueryService;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/querys")
+@RequiredArgsConstructor
+public class QueryController {
+
+    private final QueryService queryService;
+
+    @ApiOperation(value = "인기 검색어 목록 10개 조회", notes = "검색 횟수가 많은 순서대로 검색어 10개를 조회한다.")
+    @GetMapping("/favorite")
+    public List<QueryDto> listFavoriteQueries() {
+        return queryService.listFavoriteQueries();
+    }
+}

--- a/src/main/java/com/hgbong/blogsearch/entity/Query.java
+++ b/src/main/java/com/hgbong/blogsearch/entity/Query.java
@@ -1,0 +1,39 @@
+package com.hgbong.blogsearch.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.domain.Persistable;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Query implements Persistable<String> {
+
+    @Id
+    private String query;
+
+    @Column(nullable = false)
+    private long count;
+
+    public Query(String query) {
+        this.query = query;
+        this.count = 1;
+    }
+
+    @Transient
+    @Override
+    public String getId() {
+        return this.query;
+    }
+
+    @Transient
+    @Override
+    public boolean isNew() {
+        return this.count < 1;
+    }
+
+    public void addCount() {
+        this.count++;
+    }
+}

--- a/src/main/java/com/hgbong/blogsearch/model/query/QueryDto.java
+++ b/src/main/java/com/hgbong/blogsearch/model/query/QueryDto.java
@@ -1,0 +1,18 @@
+package com.hgbong.blogsearch.model.query;
+
+import io.swagger.annotations.ApiModelProperty;
+import io.swagger.annotations.ApiResponse;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString(of = {"query", "count"})
+public class QueryDto {
+    @ApiModelProperty(value = "검색어", example = "test")
+    private String query;
+
+    @ApiModelProperty(value = "검색 수", example = "100")
+    private long count;
+}

--- a/src/main/java/com/hgbong/blogsearch/repository/QueryRepository.java
+++ b/src/main/java/com/hgbong/blogsearch/repository/QueryRepository.java
@@ -1,0 +1,10 @@
+package com.hgbong.blogsearch.repository;
+
+import com.hgbong.blogsearch.entity.Query;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface QueryRepository extends JpaRepository<Query, String> {
+    List<Query> findTop10ByOrderByCountDesc();
+}

--- a/src/main/java/com/hgbong/blogsearch/service/QueryService.java
+++ b/src/main/java/com/hgbong/blogsearch/service/QueryService.java
@@ -1,0 +1,58 @@
+package com.hgbong.blogsearch.service;
+
+import com.hgbong.blogsearch.entity.Query;
+import com.hgbong.blogsearch.model.common.PageResponse;
+import com.hgbong.blogsearch.model.query.QueryDto;
+import com.hgbong.blogsearch.model.search.BlogSearchCriteria;
+import com.hgbong.blogsearch.model.search.DocumentDto;
+import com.hgbong.blogsearch.model.search.SearchEngine;
+import com.hgbong.blogsearch.repository.QueryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class QueryService {
+
+    private final QueryRepository queryRepository;
+
+    private final ModelMapper modelMapper;
+
+
+    /**
+     * 한번 이상 검색된 문자열은 카운트 1 증가시키고,
+     * 처음 검색된 문자열은 새로 추가
+     * @param queryStr
+     */
+    public void addQueryCount(String queryStr) {
+        // todo  동시성 이슈 처리
+
+        Optional<Query> opQuery = queryRepository.findById(queryStr);
+        if (opQuery.isPresent()){
+            Query query = opQuery.get();
+            query.addCount();
+            log.info("query count added. str: {}, count: {}", queryStr, query.getCount());
+        } else {
+            Query query = new Query(queryStr);
+            queryRepository.save(query);
+            log.info("query added. str: {}", queryStr);
+        }
+    }
+
+
+    public List<QueryDto> listFavoriteQueries() {
+        List<Query> queries = queryRepository.findTop10ByOrderByCountDesc();
+        return queries.stream()
+            .map(q -> modelMapper.map(q, QueryDto.class))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,19 @@
+server:
+  servlet:
+    context-path: /api
+
 spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testhgdb  # in-memory 설정
+    username: sa
+    password:
 
-
-
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    open-in-view : false
 
 
 search-engine:

--- a/src/test/java/com/hgbong/blogsearch/controller/BlogSearchControllerTest.java
+++ b/src/test/java/com/hgbong/blogsearch/controller/BlogSearchControllerTest.java
@@ -42,7 +42,6 @@ class BlogSearchControllerTest {
             .andExpect(MockMvcResultMatchers.jsonPath("$.totalCount").isNumber());
     }
 
-
     @Test
     void listBlogs_queryWithPaging() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/blogs")

--- a/src/test/java/com/hgbong/blogsearch/controller/QueryControllerTest.java
+++ b/src/test/java/com/hgbong/blogsearch/controller/QueryControllerTest.java
@@ -1,0 +1,68 @@
+package com.hgbong.blogsearch.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class QueryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void listFavoriteQueries_queryNotExists() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/querys/favorite"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.empty()));
+    }
+
+    @Test
+    void listFavoriteQueries_queryLessThan10() throws Exception {
+        for (int i = 0; i < 3; i++) {
+            mockMvc.perform(MockMvcRequestBuilders.get("/blogs")
+                .queryParam("query","test" + i));
+        }
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/querys/favorite"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(3)))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].query", Matchers.containsString("test")));
+    }
+
+
+    @Test
+    @DisplayName("15개의 검색어에 대해, 각각 1~15번 호출하고 결과의 처음과 마지막 원소 확인")
+    void listFavoriteQueries_queryMoreThan10() throws Exception {
+        for (int i = 1; i <= 15; i++) {
+            for (int j = 0; j < i; j++) {
+                mockMvc.perform(MockMvcRequestBuilders.get("/blogs")
+                    .queryParam("query","test" + i));
+            }
+        }
+
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/querys/favorite"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn().getResponse().getContentAsString();
+
+        JsonNode jsonNode = new ObjectMapper().readTree(response);
+
+        JsonNode first = jsonNode.get(0);
+        Assertions.assertEquals(first.path("query").asText(), "test15");
+        Assertions.assertEquals(first.path("count").numberValue(), 15);
+
+        JsonNode last = jsonNode.get(9);
+        Assertions.assertEquals(last.path("query").asText(), "test6");
+        Assertions.assertEquals(last.path("count").numberValue(), 6);
+    }
+}


### PR DESCRIPTION
블로그 목록 조회 시 검색어를DB에 카운트와 함께 저장
이미 저장된 검색어는 카운트 증가, 최초 입력 검색어는 새로 저장
db는 java 기반 경량의 h2 db 사용

TODO
-  동시성 고민 (동시에 같은 검색어 입력)
-  검색 서버 failover 처리